### PR TITLE
[TAR-740] Added flag to disable content trust signing for binfmt image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: bin/linuxkit
 	bin/linuxkit pkg build -org docker binfmt
 
 push: bin/linuxkit
-	bin/linuxkit pkg push -org docker binfmt
+	bin/linuxkit pkg push -disable-content-trust -org docker binfmt
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
**Description**:  To push the image to a repository, linuxkit requires a passphrase.  See the log message here: https://jenkins.dockerproject.org/job/binfmt/job/master/6/console

Adding this flag allows us to push the image without having to worry about the image being signed

cc. @seemethere @StefanScherer 