### PR TITLE
[TAR-740] Revert "added flag to disable content trust signing for binfmt image"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: bin/linuxkit
 	docker run --rm s390x/alpine uname -a
 
 push: bin/linuxkit
-	bin/linuxkit pkg push -disable-content-trust -org docker binfmt
+	bin/linuxkit pkg push -org docker binfmt
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
This reverts commit 0ae5bd03a56587eac469e38520ba2c33a1a29ef7 and removes the `-disable-content-trust` flag again.

Fixes #7 
