### PR TITLE
[TAR-742] ADDED param to enter passphrase for the user

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,10 @@ pipeline {
   agent {
       label 'linux && amd64 && ubuntu-1804 && docker'
   }
+
   parameters {
     booleanParam(name: "push", defaultValue: false)
+    string(name: 'PASSPHRASE', defaultValue: '', description: 'passphrase used to sign images')
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -28,7 +30,7 @@ pipeline {
       }
       steps {
         withDockerRegistry(url: "https://index.docker.io/v1/", credentialsId: 'dockerbuildbot-index.docker.io') {
-          sh 'make push'
+          sh 'export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$params.PASSPHRASE && make push'
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
-DOCKER_HUB_CREDS = [
+DOCKER_HUB_CREDS = [[
     $class: 'UsernamePasswordMultiBinding',
     usernameVariable: 'REGISTRY_USERNAME',
-    passwordVariable: 'REGISTRY_PASSWORD',
+    passwordVariable: 'DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE',
     credentialsId: 'dockerbuildbot-index.docker.io',
-]
+]]
 
 pipeline {
   agent {
@@ -36,10 +36,9 @@ pipeline {
         expression { params.push }
       }
       steps {
-        sh 'make bin/linuxkit'
         withDockerRegistry(url: "https://index.docker.io/v1/", credentialsId: 'dockerbuildbot-index.docker.io') {
-          withCredentials(DOCKER_HUB_CREDS){
-            sh 'export DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$REGISTRY_PASSWORD && bin/linuxkit pkg push -org docker binfmt'
+          withCredentials(DOCKER_HUB_CREDS) {
+            sh 'export $DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE=$DOCKER_CONTENT_TRUST_REPOSITORY_PASSPHRASE && bin/linuxkit pkg push -org docker binfmt'
           }
         }
       }


### PR DESCRIPTION
Re-opening as I accidently deleted the branch

Description:
Linuxkit requires an environment variable to be set when signing images. If the environment variable isn't set then the following error shows up: Linuxkit reference

The workaround here is to provide the passphrase as a parameter in Jenkins, which the user provides as an input when they run the job

Alternate approach
We can also get around this by having the passphrase as a credential stored in Jenkins. I haven't seen this there or I might have missed it. However this could work as we don't have to provide a parameter for the users

@StefanScherer @docker/tools-and-release-engineering