### PR TITLE
Revert "[TAR-740] Revert "added flag to disable content trust signing for binfmt image""

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test: bin/linuxkit
 	docker run --rm s390x/alpine uname -a
 
 push: bin/linuxkit
-	bin/linuxkit pkg push -org docker binfmt
+	bin/linuxkit pkg push -disable-content-trust -org docker binfmt
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
Reverts docker/binfmt#8 - Releasing an unsigned image for binfmt

@StefanScherer 