### PR TITLE
[TAR-622] Add manifest-tool

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
   stages {
     stage('build') {
       steps {
+        sh 'make clean'
         sh 'make build'
       }
     }

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,13 @@ ALL: build
 
 bin/linuxkit:
 	curl -Lo bin/linuxkit https://github.com/linuxkit/linuxkit/releases/download/v0.7/linuxkit-linux-amd64
+	echo "c747033343315774b6e51f618eb143d5714e398a32b59b9b6acab23b599dd970  bin/linuxkit" | sha256sum --check
 	chmod +x bin/linuxkit
+
+bin/manifest-tool:
+	curl -Lo bin/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v0.9.0/manifest-tool-linux-amd64
+	echo "80906341c3306e3838437eeb08fff5da2c38bd89149019aa301c7745e07ea8f9  bin/manifest-tool" | sha256sum --check
+	chmod +x bin/manifest-tool
 
 build: bin/linuxkit
 	bin/linuxkit pkg build -org docker binfmt
@@ -15,8 +21,8 @@ test: bin/linuxkit
 	docker run --rm ppc64le/alpine uname -a
 	docker run --rm s390x/alpine uname -a
 
-push: bin/linuxkit
-	bin/linuxkit pkg push -disable-content-trust -org docker binfmt
+push: bin/linuxkit bin/manifest-tool
+	export PATH=$(CURDIR)/bin:$$PATH ; bin/linuxkit pkg push -disable-content-trust -org docker binfmt
 
 clean:
 	rm -f bin/*


### PR DESCRIPTION
Check downloaded tools.

A previous push resulted in this error:
```
22:52:35 Pushing docker/binfmt:4aa6395220b2a23c6fba0cdd5fe594be51770202-amd64 to manifest docker/binfmt:4aa6395220b2a23c6fba0cdd5fe594be51770202
22:52:35 cat: /home/ubuntu/.docker/config.json: No such file or directory
22:52:35 cat: /home/ubuntu/.docker/config.json: No such file or directory
22:52:35 manifest-push-script: 60: manifest-push-script: manifest-tool: not found
```

So, now also install the manifest-tool.
